### PR TITLE
Fix player spawn candidate check

### DIFF
--- a/src/world/ChunkManager.ts
+++ b/src/world/ChunkManager.ts
@@ -176,6 +176,9 @@ export class ChunkManager {
   }
 
   private isValidCandidate(x: number, y: number, z: number): boolean {
+    // Verifica que los voxeles adyacentes estén libres. Esto incluye las
+    // cuatro diagonales, asegurando suficiente espacio alrededor del punto de
+    // spawn potencial.
     return this.isVoxelFree(x, y, z, VoxelType.AIR) &&
       this.isVoxelFree(x, y + 1, z, VoxelType.AIR) &&
       this.isVoxelFree(x + 1, y, z, VoxelType.AIR) &&
@@ -183,9 +186,9 @@ export class ChunkManager {
       this.isVoxelFree(x, y, z + 1, VoxelType.AIR) &&
       this.isVoxelFree(x, y, z - 1, VoxelType.AIR) &&
       this.isVoxelFree(x + 1, y, z + 1, VoxelType.AIR) &&
+      this.isVoxelFree(x + 1, y, z - 1, VoxelType.AIR) &&
+      this.isVoxelFree(x - 1, y, z + 1, VoxelType.AIR) &&
       this.isVoxelFree(x - 1, y, z - 1, VoxelType.AIR) &&
-      this.isVoxelFree(x - 1, y, z - 1, VoxelType.AIR) &&
-      this.isVoxelFree(x + 1, y, z + 1, VoxelType.AIR) &&
       this.isVoxelFree(x, y - 1, z, VoxelType.GRASS);
   }
 


### PR DESCRIPTION
## Summary
- fix the voxel checks used to locate safe spawn positions
- add a comment explaining the diagonal checks

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4905a8bc832bbcfc77520c9e000c