### PR TITLE
Allow configurable terrain generation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,10 +6,29 @@ import { UIManager } from './ui/UIManager';
 import { Controls } from './player/Controls';
 import { InputManager } from './player/InputManager';
 import { ChunkManager } from './world/ChunkManager';
+import { TerrainConfig } from './world/TerrainConfig';
 
 async function init() {
   const renderer = new Renderer();
-  const chunkManager = new ChunkManager(renderer.scene);
+  const url = new URL(location.href);
+  const terrainParams = [
+    'maxHeight', 'seaLevel', 'baseFrequency', 'baseAmplitude',
+    'mountainFrequency', 'mountainThreshold', 'mountainAmplitude',
+    'oceanFrequency', 'oceanThreshold', 'oceanAmplitude',
+    'detailFrequency', 'detailAmplitude', 'tempFrequency',
+    'rainFrequency', 'rainAmplitude', 'treeFrequency',
+    'caveCount', 'minCaveLength', 'maxCaveLength', 'baseCaveRadius',
+    'octaves', 'persistence', 'lacunarity',
+    'oceanFloorHeight', 'prairieMaxHeight'
+  ];
+  const terrainConfig: TerrainConfig = {};
+  for (const p of terrainParams) {
+    const val = url.searchParams.get(p);
+    if (val !== null) {
+      (terrainConfig as any)[p] = parseFloat(val);
+    }
+  }
+  const chunkManager = new ChunkManager(renderer.scene, terrainConfig);
   const world = new World(renderer, chunkManager);
   const player = new Player(renderer, world);
   const inputManager = new InputManager(renderer.camera, renderer.scene, chunkManager);

--- a/src/world/ChunkManager.ts
+++ b/src/world/ChunkManager.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { Chunk } from './Chunk';
 import { TerrainGenerator, VoxelType } from './TerrainGenerator';
+import { TerrainConfig } from './TerrainConfig';
 
 export class ChunkManager {
   private scene: THREE.Scene;
@@ -16,12 +17,12 @@ export class ChunkManager {
   private loadCounter: number = 2;
   private firstChunksLoaded: boolean = false;
 
-  constructor(scene: THREE.Scene) {
+  constructor(scene: THREE.Scene, config: TerrainConfig = {}) {
     this.scene = scene;
     this.chunks = new Map();
     this.modifiedChunks = new Map();
     const url = new URL(location.href);
-    this.terrainGenerator = new TerrainGenerator(url.searchParams.get("seed"));
+    this.terrainGenerator = new TerrainGenerator(url.searchParams.get("seed"), config);
   }
 
   public update(playerPosition: THREE.Vector3) {

--- a/src/world/TerrainConfig.ts
+++ b/src/world/TerrainConfig.ts
@@ -1,0 +1,27 @@
+export interface TerrainConfig {
+  maxHeight?: number;
+  seaLevel?: number;
+  baseFrequency?: number;
+  baseAmplitude?: number;
+  mountainFrequency?: number;
+  mountainThreshold?: number;
+  mountainAmplitude?: number;
+  oceanFrequency?: number;
+  oceanThreshold?: number;
+  oceanAmplitude?: number;
+  detailFrequency?: number;
+  detailAmplitude?: number;
+  tempFrequency?: number;
+  rainFrequency?: number;
+  rainAmplitude?: number;
+  treeFrequency?: number;
+  caveCount?: number;
+  minCaveLength?: number;
+  maxCaveLength?: number;
+  baseCaveRadius?: number;
+  octaves?: number;
+  persistence?: number;
+  lacunarity?: number;
+  oceanFloorHeight?: number;
+  prairieMaxHeight?: number;
+}

--- a/src/world/TerrainGenerator.ts
+++ b/src/world/TerrainGenerator.ts
@@ -1,5 +1,6 @@
 import { SimplexNoiseGenerator } from '../utils/SimpleNoiseGenerator';
 import * as THREE from 'three';
+import { TerrainConfig } from './TerrainConfig';
 
 export enum VoxelType {
   AIR = 0,
@@ -18,47 +19,113 @@ export enum VoxelType {
   BEDROCK
 }
 
+const DEFAULT_CONFIG: Required<TerrainConfig> = {
+  maxHeight: 256,
+  seaLevel: 48,
+  baseFrequency: 0.001,
+  baseAmplitude: 5,
+  mountainFrequency: 0.002,
+  mountainThreshold: 0.6,
+  mountainAmplitude: 400,
+  oceanFrequency: 0.001,
+  oceanThreshold: 0.65,
+  oceanAmplitude: 120,
+  detailFrequency: 0.06,
+  detailAmplitude: 6,
+  tempFrequency: 0.0125,
+  rainFrequency: 0.01,
+  rainAmplitude: 1,
+  treeFrequency: 0.15,
+  caveCount: 3,
+  minCaveLength: 50,
+  maxCaveLength: 150,
+  baseCaveRadius: 2,
+  octaves: 4,
+  persistence: 3,
+  lacunarity: 2.3,
+  oceanFloorHeight: 20,
+  prairieMaxHeight: 80,
+};
+
 export class TerrainGenerator {
-  private readonly maxHeight: number = 256;
-  private readonly seaLevel: number = 48;
+  private readonly maxHeight: number;
+  private readonly seaLevel: number;
 
-  private readonly baseFrequency: number = 0.001;
-  private readonly baseAmplitude: number = 5;
+  private readonly baseFrequency: number;
+  private readonly baseAmplitude: number;
 
-  private readonly mountainFrequency: number = 0.002;
-  private readonly mountainThreshold: number = 0.6;
-  private readonly mountainAmplitude: number = 400;
+  private readonly mountainFrequency: number;
+  private readonly mountainThreshold: number;
+  private readonly mountainAmplitude: number;
 
-  private readonly oceanFrequency: number = 0.001;
-  private readonly oceanThreshold: number = 0.65;
-  private readonly oceanAmplitude: number = 120;
+  private readonly oceanFrequency: number;
+  private readonly oceanThreshold: number;
+  private readonly oceanAmplitude: number;
 
-  private readonly detailFrequency: number = 0.06;
-  private readonly detailAmplitude: number = 6;
+  private readonly detailFrequency: number;
+  private readonly detailAmplitude: number;
 
-  private readonly tempFrequency: number = 0.0125;
+  private readonly tempFrequency: number;
 
-  private readonly rainFrequency: number = 0.01;
-  private readonly rainAmplitude: number = 1;
+  private readonly rainFrequency: number;
+  private readonly rainAmplitude: number;
 
-  private readonly treeFrequency: number = 0.15;
+  private readonly treeFrequency: number;
 
-  private readonly caveCount: number = 3;
-  private readonly minCaveLength: number = 50;
-  private readonly maxCaveLength: number = 150;
-  private readonly baseCaveRadius: number = 2;
+  private readonly caveCount: number;
+  private readonly minCaveLength: number;
+  private readonly maxCaveLength: number;
+  private readonly baseCaveRadius: number;
 
-  private octaves: number = 4;
-  private persistence: number = 3;
-  private lacunarity: number = 2.3;
+  private octaves: number;
+  private persistence: number;
+  private lacunarity: number;
 
-  private oceanFloorHeight: number = 20;
-  private prairieMaxHeight: number = 80;
+  private oceanFloorHeight: number;
+  private prairieMaxHeight: number;
 
 
   private noiseGen: SimplexNoiseGenerator;
 
-  constructor(seed: string | null) {
+  constructor(seed: string | null, config: TerrainConfig = {}) {
+    const cfg = { ...DEFAULT_CONFIG, ...config };
+
+    this.maxHeight = cfg.maxHeight;
+    this.seaLevel = cfg.seaLevel;
+
+    this.baseFrequency = cfg.baseFrequency;
+    this.baseAmplitude = cfg.baseAmplitude;
+
+    this.mountainFrequency = cfg.mountainFrequency;
+    this.mountainThreshold = cfg.mountainThreshold;
+    this.mountainAmplitude = cfg.mountainAmplitude;
+
+    this.oceanFrequency = cfg.oceanFrequency;
+    this.oceanThreshold = cfg.oceanThreshold;
+    this.oceanAmplitude = cfg.oceanAmplitude;
+
+    this.detailFrequency = cfg.detailFrequency;
+    this.detailAmplitude = cfg.detailAmplitude;
+
+    this.tempFrequency = cfg.tempFrequency;
+
+    this.rainFrequency = cfg.rainFrequency;
+    this.rainAmplitude = cfg.rainAmplitude;
+
+    this.treeFrequency = cfg.treeFrequency;
+
+    this.caveCount = cfg.caveCount;
+    this.minCaveLength = cfg.minCaveLength;
+    this.maxCaveLength = cfg.maxCaveLength;
+    this.baseCaveRadius = cfg.baseCaveRadius;
+
+    this.octaves = cfg.octaves;
+    this.persistence = cfg.persistence;
+    this.lacunarity = cfg.lacunarity;
+
+    this.oceanFloorHeight = cfg.oceanFloorHeight;
+    this.prairieMaxHeight = cfg.prairieMaxHeight;
+
     this.noiseGen = new SimplexNoiseGenerator(seed);
   }
 


### PR DESCRIPTION
## Summary
- add a `TerrainConfig` interface for terrain parameters
- use the config when creating a `TerrainGenerator`
- let `ChunkManager` pass config to the generator
- parse terrain settings from query parameters in `main.ts`

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e4f676ee8832ba22a98090482d1a6