### PR TITLE
Add basic NPC system with zombies

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { Controls } from './player/Controls';
 import { InputManager } from './player/InputManager';
 import { ChunkManager } from './world/ChunkManager';
 import { TerrainConfig } from './world/TerrainConfig';
+import * as THREE from 'three';
 
 async function init() {
   const renderer = new Renderer();
@@ -35,6 +36,8 @@ async function init() {
   const controls = new Controls(player, renderer.domElement, inputManager);
   const audioManager = new AudioManager();
   const uiManager = new UIManager();
+
+  world.spawnZombie(new THREE.Vector3(5, 50, 5));
 
   let lastTime = performance.now();
   let accumulator = 0;

--- a/src/npc/Enemy.ts
+++ b/src/npc/Enemy.ts
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+import { ChunkManager } from '../world/ChunkManager';
+import { Pathfinder } from './Pathfinder';
+
+export abstract class Enemy {
+  public position: THREE.Vector3;
+  public velocity: THREE.Vector3 = new THREE.Vector3();
+  public mesh: THREE.Mesh;
+  protected path: THREE.Vector3[] = [];
+  protected pathIndex: number = 0;
+  protected speed: number = 2;
+  protected pathfinder: Pathfinder;
+  protected chunkManager: ChunkManager;
+
+  constructor(position: THREE.Vector3, chunkManager: ChunkManager) {
+    this.position = position.clone();
+    this.chunkManager = chunkManager;
+    this.pathfinder = new Pathfinder(chunkManager);
+    this.mesh = this.createMesh();
+    this.mesh.position.copy(this.position);
+  }
+
+  protected abstract createMesh(): THREE.Mesh;
+
+  public update(delta: number, target: THREE.Vector3) {
+    if (this.path.length === 0 || this.pathIndex >= this.path.length) {
+      this.path = this.pathfinder.findPath(this.position, target);
+      this.pathIndex = 0;
+    }
+    if (this.path.length > 0 && this.pathIndex < this.path.length) {
+      const next = this.path[this.pathIndex];
+      const dir = next.clone().sub(this.position);
+      if (dir.lengthSq() < 0.01) {
+        this.pathIndex++;
+      } else {
+        dir.normalize();
+        this.velocity.copy(dir.multiplyScalar(this.speed));
+        this.position.addScaledVector(this.velocity, delta);
+        this.mesh.position.copy(this.position);
+      }
+    }
+  }
+}

--- a/src/npc/EnemyManager.ts
+++ b/src/npc/EnemyManager.ts
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+import { Zombie } from './Zombie';
+import { World } from '../world/World';
+import { ChunkManager } from '../world/ChunkManager';
+
+export class EnemyManager {
+  private enemies: Zombie[] = [];
+  private world: World;
+  private chunkManager: ChunkManager;
+
+  constructor(world: World, chunkManager: ChunkManager) {
+    this.world = world;
+    this.chunkManager = chunkManager;
+  }
+
+  public spawnZombie(position: THREE.Vector3) {
+    const zombie = new Zombie(position, this.chunkManager);
+    this.enemies.push(zombie);
+    this.world.scene.add(zombie.mesh);
+  }
+
+  public update(delta: number, playerPosition: THREE.Vector3) {
+    for (const e of this.enemies) {
+      e.update(delta, playerPosition);
+    }
+  }
+}

--- a/src/npc/Pathfinder.ts
+++ b/src/npc/Pathfinder.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+import { ChunkManager } from '../world/ChunkManager';
+import { VoxelType } from '../world/TerrainGenerator';
+
+interface Node {
+  pos: THREE.Vector3;
+  parent: Node | null;
+}
+
+export class Pathfinder {
+  constructor(private chunkManager: ChunkManager) {}
+
+  private key(x: number, y: number, z: number): string {
+    return `${x},${y},${z}`;
+  }
+
+  private isWalkable(x: number, y: number, z: number): boolean {
+    const ground = this.chunkManager.getVoxelType(x, y - 1, z);
+    if (ground === null || ground === VoxelType.AIR) return false;
+    const head = this.chunkManager.getVoxelType(x, y, z);
+    const above = this.chunkManager.getVoxelType(x, y + 1, z);
+    return (head === null || head === VoxelType.AIR) && (above === null || above === VoxelType.AIR);
+  }
+
+  public findPath(start: THREE.Vector3, goal: THREE.Vector3, maxSteps = 512): THREE.Vector3[] {
+    const sx = Math.floor(start.x);
+    const sy = Math.floor(start.y);
+    const sz = Math.floor(start.z);
+    const gx = Math.floor(goal.x);
+    const gy = Math.floor(goal.y);
+    const gz = Math.floor(goal.z);
+
+    const open: Node[] = [{ pos: new THREE.Vector3(sx, sy, sz), parent: null }];
+    const visited = new Set<string>();
+    visited.add(this.key(sx, sy, sz));
+    let targetNode: Node | null = null;
+
+    while (open.length > 0 && maxSteps-- > 0) {
+      const current = open.shift()!;
+      if (current.pos.x === gx && current.pos.y === gy && current.pos.z === gz) {
+        targetNode = current;
+        break;
+      }
+      const dirs = [
+        new THREE.Vector3(1, 0, 0),
+        new THREE.Vector3(-1, 0, 0),
+        new THREE.Vector3(0, 0, 1),
+        new THREE.Vector3(0, 0, -1)
+      ];
+      for (const d of dirs) {
+        for (let dy = -1; dy <= 1; dy++) {
+          const nx = current.pos.x + d.x;
+          const ny = current.pos.y + dy;
+          const nz = current.pos.z + d.z;
+          if (Math.abs(ny - current.pos.y) > 1) continue;
+          const k = this.key(nx, ny, nz);
+          if (visited.has(k)) continue;
+          if (this.isWalkable(nx, ny, nz)) {
+            visited.add(k);
+            open.push({ pos: new THREE.Vector3(nx, ny, nz), parent: current });
+          }
+        }
+      }
+    }
+
+    const path: THREE.Vector3[] = [];
+    if (targetNode) {
+      let n: Node | null = targetNode;
+      while (n) {
+        path.push(n.pos.clone());
+        n = n.parent;
+      }
+      path.reverse();
+    }
+    return path;
+  }
+}

--- a/src/npc/Zombie.ts
+++ b/src/npc/Zombie.ts
@@ -1,0 +1,11 @@
+import * as THREE from 'three';
+import { Enemy } from './Enemy';
+import { ChunkManager } from '../world/ChunkManager';
+
+export class Zombie extends Enemy {
+  protected createMesh(): THREE.Mesh {
+    const geometry = new THREE.BoxGeometry(0.6, 1.8, 0.6);
+    const material = new THREE.MeshLambertMaterial({ color: 0x84c37c });
+    return new THREE.Mesh(geometry, material);
+  }
+}

--- a/src/world/ChunkManager.ts
+++ b/src/world/ChunkManager.ts
@@ -204,4 +204,16 @@ export class ChunkManager {
     if (globalY < 0 || globalY >= chunk.terrainData[localX].length) return false;
     return chunk.terrainData[localX][globalY][localZ] === voxelType;
   }
+
+  public getVoxelType(globalX: number, globalY: number, globalZ: number): VoxelType | null {
+    const chunkX = Math.floor(globalX / this.chunkSize);
+    const chunkZ = Math.floor(globalZ / this.chunkSize);
+    const chunk = this.getChunkAt(chunkX, chunkZ);
+    if (!chunk) return null;
+    const localX = globalX - chunk.x * this.chunkSize;
+    const localZ = globalZ - chunk.z * this.chunkSize;
+    if (localX < 0 || localX >= chunk.size || localZ < 0 || localZ >= chunk.size) return null;
+    if (globalY < 0 || globalY >= chunk.terrainData[localX].length) return null;
+    return chunk.terrainData[localX][globalY][localZ];
+  }
 }

--- a/src/world/World.ts
+++ b/src/world/World.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { ChunkManager } from './ChunkManager';
 import { Chunk } from './Chunk';
 import { Renderer } from '../graphics/Renderer';
+import { EnemyManager } from '../npc/EnemyManager';
 
 export class World {
   public scene: THREE.Scene;
@@ -11,6 +12,7 @@ export class World {
 
   private readonly chunkManager: ChunkManager;
   private readonly renderer: Renderer;
+  private enemyManager: EnemyManager;
   private cycleTime: number = 0;
 
   private totalCycleTime: number = 0;
@@ -19,6 +21,7 @@ export class World {
     this.scene = renderer.scene;
     this.chunkManager = chunkManager;
     this.renderer = renderer;
+    this.enemyManager = new EnemyManager(this, chunkManager);
     this.totalCycleTime =
       this.renderer.dayNightConfig.dayDuration +
       this.renderer.dayNightConfig.transitionDuration +
@@ -29,6 +32,7 @@ export class World {
   update(delta: number, playerPosition: THREE.Vector3) {
     this.updateDayNightCycle(delta);
     this.chunkManager.update(playerPosition);
+    this.enemyManager.update(delta, playerPosition);
   }
 
   public getLoadedChunks(): Chunk[] {
@@ -41,6 +45,10 @@ export class World {
 
   public getClosestFreePosition(position: THREE.Vector3): THREE.Vector3 {
     return this.chunkManager.closestFreeSpace(position);
+  }
+
+  public spawnZombie(position: THREE.Vector3) {
+    this.enemyManager.spawnZombie(position);
   }
 
   private updateDayNightCycle(delta: number) {


### PR DESCRIPTION
## Summary
- create generic `Enemy` class with simple path following
- implement BFS `Pathfinder`
- add `Zombie` enemy with procedural cube mesh
- manage enemies via `EnemyManager` integrated in `World`
- expose `spawnZombie` and spawn one zombie in `main`
- expose voxel query method in `ChunkManager`

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e56430d2c832b8d4913a95b5fb58c