### PR TITLE
Spawn zombies near player at night

### DIFF
--- a/src/npc/MobManager.ts
+++ b/src/npc/MobManager.ts
@@ -21,21 +21,20 @@ export class MobManager {
     this.world.scene.add(zombie.mesh);
   }
 
-  private spawnNightMobs() {
+  private spawnNightMobs(playerPos: THREE.Vector3) {
     const count = 5;
     for (let i = 0; i < count; i++) {
-      const pos = this.findSpawnPosition();
+      const pos = this.findSpawnPositionNearPlayer(playerPos);
       if (pos) this.spawnZombie(pos);
     }
   }
 
-  private findSpawnPosition(): THREE.Vector3 | null {
-    const chunks = this.world.getLoadedChunks();
-    if (chunks.length === 0) return null;
+  private findSpawnPositionNearPlayer(playerPos: THREE.Vector3): THREE.Vector3 | null {
     for (let attempt = 0; attempt < 20; attempt++) {
-      const chunk = chunks[Math.floor(Math.random() * chunks.length)];
-      const x = chunk.x * chunk.size + Math.floor(Math.random() * chunk.size);
-      const z = chunk.z * chunk.size + Math.floor(Math.random() * chunk.size);
+      const angle = Math.random() * Math.PI * 2;
+      const distance = 15 + Math.random() * 10; // alrededor de 20 bloques
+      const x = Math.floor(playerPos.x + Math.cos(angle) * distance);
+      const z = Math.floor(playerPos.z + Math.sin(angle) * distance);
       for (let y = 255; y > 0; y--) {
         const type = this.chunkManager.getVoxelType(x, y, z);
         if (type === null || type === VoxelType.AIR) continue;
@@ -63,7 +62,7 @@ export class MobManager {
     const isNight = this.world.isNight();
     if (isNight) {
       if (!this.spawned) {
-        this.spawnNightMobs();
+        this.spawnNightMobs(playerPosition);
         this.spawned = true;
       }
     } else {

--- a/src/npc/Zombie.ts
+++ b/src/npc/Zombie.ts
@@ -1,7 +1,19 @@
 import * as THREE from 'three';
 import { Mob } from './Mob';
+import { ChunkManager } from '../world/ChunkManager';
 
 export class Zombie extends Mob {
+  private state: 'wandering' | 'chasing' = 'wandering';
+  private spawnPoint: THREE.Vector3;
+  private wanderTarget: THREE.Vector3 | null = null;
+  private readonly detectRange = 10;
+  private readonly wanderRadius = 5;
+
+  constructor(position: THREE.Vector3, chunkManager: ChunkManager) {
+    super(position, chunkManager);
+    this.spawnPoint = position.clone();
+  }
+
   protected createMesh(): THREE.Object3D {
     const material = new THREE.MeshLambertMaterial({ color: 0x84c37c });
 
@@ -20,5 +32,39 @@ export class Zombie extends Mob {
     const group = new THREE.Group();
     group.add(head, body, leftLeg, rightLeg);
     return group;
+  }
+
+  public update(delta: number, playerPos: THREE.Vector3) {
+    const distToPlayer = this.position.distanceTo(playerPos);
+
+    if (distToPlayer <= this.detectRange) {
+      if (this.state !== 'chasing') {
+        this.state = 'chasing';
+        this.path = [];
+        this.pathIndex = 0;
+      }
+      super.update(delta, playerPos);
+      return;
+    }
+
+    if (this.state !== 'wandering') {
+      this.state = 'wandering';
+      this.wanderTarget = null;
+      this.path = [];
+      this.pathIndex = 0;
+    }
+
+    if (!this.wanderTarget || this.position.distanceTo(this.wanderTarget) < 1) {
+      const angle = Math.random() * Math.PI * 2;
+      const dist = Math.random() * this.wanderRadius;
+      this.wanderTarget = this.spawnPoint.clone().add(
+        new THREE.Vector3(Math.cos(angle) * dist, 0, Math.sin(angle) * dist)
+      );
+      this.wanderTarget.y = this.spawnPoint.y;
+      this.path = [];
+      this.pathIndex = 0;
+    }
+
+    super.update(delta, this.wanderTarget);
   }
 }


### PR DESCRIPTION
## Summary
- spawn zombies near the player at night
- add wandering and chasing behaviour to zombies

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'three')*

------
https://chatgpt.com/codex/tasks/task_e_684e5ccecb6c832bb6ca638fdad150b7