### PR TITLE
Improve zombie navigation

### DIFF
--- a/src/npc/Pathfinder.ts
+++ b/src/npc/Pathfinder.ts
@@ -4,6 +4,9 @@ import { VoxelType } from '../world/TerrainGenerator';
 
 interface Node {
   pos: THREE.Vector3;
+  g: number;
+  h: number;
+  f: number;
   parent: Node | null;
 }
 
@@ -14,7 +17,7 @@ export class Pathfinder {
     return `${x},${y},${z}`;
   }
 
-  private isWalkable(x: number, y: number, z: number): boolean {
+  public isWalkable(x: number, y: number, z: number): boolean {
     const ground = this.chunkManager.getVoxelType(x, y - 1, z);
     if (ground === null || ground === VoxelType.AIR) return false;
     const head = this.chunkManager.getVoxelType(x, y, z);
@@ -22,7 +25,7 @@ export class Pathfinder {
     return (head === null || head === VoxelType.AIR) && (above === null || above === VoxelType.AIR);
   }
 
-  public findPath(start: THREE.Vector3, goal: THREE.Vector3, maxSteps = 512): THREE.Vector3[] {
+  public findPath(start: THREE.Vector3, goal: THREE.Vector3, maxSteps = 2048): THREE.Vector3[] {
     const sx = Math.floor(start.x);
     const sy = Math.floor(start.y);
     const sz = Math.floor(start.z);
@@ -30,35 +33,61 @@ export class Pathfinder {
     const gy = Math.floor(goal.y);
     const gz = Math.floor(goal.z);
 
-    const open: Node[] = [{ pos: new THREE.Vector3(sx, sy, sz), parent: null }];
-    const visited = new Set<string>();
-    visited.add(this.key(sx, sy, sz));
+    const startNode: Node = {
+      pos: new THREE.Vector3(sx, sy, sz),
+      g: 0,
+      h: 0,
+      f: 0,
+      parent: null
+    };
+
+    startNode.h = Math.abs(gx - sx) + Math.abs(gy - sy) + Math.abs(gz - sz);
+    startNode.f = startNode.h;
+
+    const open: Node[] = [startNode];
+    const cost = new Map<string, number>();
+    cost.set(this.key(sx, sy, sz), 0);
     let targetNode: Node | null = null;
 
+    const dirs = [
+      new THREE.Vector3(1, 0, 0),
+      new THREE.Vector3(-1, 0, 0),
+      new THREE.Vector3(0, 0, 1),
+      new THREE.Vector3(0, 0, -1)
+    ];
+
     while (open.length > 0 && maxSteps-- > 0) {
+      open.sort((a, b) => a.f - b.f);
       const current = open.shift()!;
+
       if (current.pos.x === gx && current.pos.y === gy && current.pos.z === gz) {
         targetNode = current;
         break;
       }
-      const dirs = [
-        new THREE.Vector3(1, 0, 0),
-        new THREE.Vector3(-1, 0, 0),
-        new THREE.Vector3(0, 0, 1),
-        new THREE.Vector3(0, 0, -1)
-      ];
+
       for (const d of dirs) {
         for (let dy = -1; dy <= 1; dy++) {
           const nx = current.pos.x + d.x;
           const ny = current.pos.y + dy;
           const nz = current.pos.z + d.z;
           if (Math.abs(ny - current.pos.y) > 1) continue;
+          if (!this.isWalkable(nx, ny, nz)) continue;
+
           const k = this.key(nx, ny, nz);
-          if (visited.has(k)) continue;
-          if (this.isWalkable(nx, ny, nz)) {
-            visited.add(k);
-            open.push({ pos: new THREE.Vector3(nx, ny, nz), parent: current });
-          }
+          const newG = current.g + 1;
+          const existing = cost.get(k);
+          if (existing !== undefined && existing <= newG) continue;
+
+          const h = Math.abs(gx - nx) + Math.abs(gy - ny) + Math.abs(gz - nz);
+          const node: Node = {
+            pos: new THREE.Vector3(nx, ny, nz),
+            g: newG,
+            h,
+            f: newG + h,
+            parent: current
+          };
+          cost.set(k, newG);
+          open.push(node);
         }
       }
     }


### PR DESCRIPTION
## Summary
- implement A* style pathfinding for mobs with public `isWalkable`
- allow mob movement to validate walkable positions and recompute paths less often

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e5f8032bc832b95afdab42fe1ab9f