### PR TITLE
Improve NPC mobility and brightness

### DIFF
--- a/src/npc/Mob.ts
+++ b/src/npc/Mob.ts
@@ -40,15 +40,19 @@ export abstract class Mob {
     if (this.path.length > 0 && this.pathIndex < this.path.length) {
       const next = this.path[this.pathIndex];
       const dir = next.clone().sub(this.position);
-      if (dir.lengthSq() < 0.01) {
+      const dist = dir.length();
+      if (dist < 0.01) {
+        this.position.copy(next);
+        this.mesh.position.copy(this.position);
         this.pathIndex++;
       } else {
         dir.normalize();
-        const step = dir.multiplyScalar(this.speed * delta);
+        const stepLength = Math.min(this.speed * delta, dist);
+        const step = dir.multiplyScalar(stepLength);
         const newPos = this.position.clone().add(step);
-        const nx = Math.floor(newPos.x);
-        const ny = Math.floor(newPos.y);
-        const nz = Math.floor(newPos.z);
+        const nx = Math.floor(next.x);
+        const ny = Math.floor(next.y);
+        const nz = Math.floor(next.z);
 
         if (this.pathfinder.isWalkable(nx, ny, nz)) {
           this.position.copy(newPos);

--- a/src/npc/Pathfinder.ts
+++ b/src/npc/Pathfinder.ts
@@ -57,8 +57,12 @@ export class Pathfinder {
     ];
 
     while (open.length > 0 && maxSteps-- > 0) {
-      open.sort((a, b) => a.f - b.f);
-      const current = open.shift()!;
+      // Find node with lowest f without sorting entire array
+      let currentIndex = 0;
+      for (let i = 1; i < open.length; i++) {
+        if (open[i].f < open[currentIndex].f) currentIndex = i;
+      }
+      const current = open.splice(currentIndex, 1)[0];
 
       if (current.pos.x === gx && current.pos.y === gy && current.pos.z === gz) {
         targetNode = current;

--- a/src/npc/Zombie.ts
+++ b/src/npc/Zombie.ts
@@ -15,7 +15,11 @@ export class Zombie extends Mob {
   }
 
   protected createMesh(): THREE.Object3D {
-    const material = new THREE.MeshLambertMaterial({ color: 0x84c37c });
+    const material = new THREE.MeshLambertMaterial({
+      color: 0xa4e38c,
+      emissive: 0x335533,
+      emissiveIntensity: 0.5
+    });
 
     const head = new THREE.Mesh(new THREE.BoxGeometry(0.6, 0.4, 0.6), material);
     head.position.y = 1.6;


### PR DESCRIPTION
## Summary
- allow mobs to climb up to one block and move smoothly
- brighten zombie material to see them at night
- optimize pathfinding loop

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e64a00244832bacdbb9f221cb6c61