### PR TITLE
Handle unloaded chunks in pathfinding

### DIFF
--- a/src/world/ChunkManager.ts
+++ b/src/world/ChunkManager.ts
@@ -16,6 +16,8 @@ export class ChunkManager {
 
   private loadCounter: number = 2;
   private firstChunksLoaded: boolean = false;
+  private currentChunkX: number = 0;
+  private currentChunkZ: number = 0;
 
   constructor(scene: THREE.Scene, config: TerrainConfig = {}) {
     this.scene = scene;
@@ -27,10 +29,10 @@ export class ChunkManager {
 
   public update(playerPosition: THREE.Vector3) {
     //this.updateShaders();
-    const currentChunkX = Math.floor(playerPosition.x / this.chunkSize);
-    const currentChunkZ = Math.floor(playerPosition.z / this.chunkSize);
-    this.deleteChunks(currentChunkX, currentChunkZ);
-    this.setChunksToLoad(currentChunkX, currentChunkZ);
+    this.currentChunkX = Math.floor(playerPosition.x / this.chunkSize);
+    this.currentChunkZ = Math.floor(playerPosition.z / this.chunkSize);
+    this.deleteChunks(this.currentChunkX, this.currentChunkZ);
+    this.setChunksToLoad(this.currentChunkX, this.currentChunkZ);
 
     if (--this.loadCounter <= 0) {
       this.loadNextChunk();
@@ -49,6 +51,21 @@ export class ChunkManager {
 
   public isWorldLoaded(): boolean {
     return this.firstChunksLoaded;
+  }
+
+  public getRenderDistance(): number {
+    return this.renderDistance;
+  }
+
+  public getPlayerChunk(): THREE.Vector2 {
+    return new THREE.Vector2(this.currentChunkX, this.currentChunkZ);
+  }
+
+  public requestChunkLoad(chunkX: number, chunkZ: number): void {
+    const key = this.getChunkKey(chunkX, chunkZ);
+    if (this.chunks.has(key) || this.loadingChunksKeys.find(c => c.x === chunkX && c.y === chunkZ)) return;
+    this.loadingChunksKeys.push(new THREE.Vector2(chunkX, chunkZ));
+    this.loadingChunks = true;
   }
 
   private updateShaders(): void {


### PR DESCRIPTION
## Summary
- track player chunk and expose render distance
- allow Pathfinder to walk through unloaded chunks when within render distance
- request chunk loads as pathfinder explores

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e6889094c832baeee941304a947f3