### PR TITLE
Use typed array for chunk voxel storage

### DIFF
--- a/src/player/InputManager.ts
+++ b/src/player/InputManager.ts
@@ -38,7 +38,7 @@ export class InputManager {
       addCoords.z
     );
     if (!addData) return;
-    if (addData.chunk.terrainData[addData.localX][addCoords.y][addData.localZ] !== VoxelType.AIR)
+    if (addData.chunk.getVoxel(addData.localX, addCoords.y, addData.localZ) !== VoxelType.AIR)
       return;
     addData.chunk.updateVoxel(addData.localX, addCoords.y, addData.localZ, VoxelType.TRUNK);
   }
@@ -54,7 +54,7 @@ export class InputManager {
       voxelCoords.z
     );
     if (!targetData) return;
-    if (targetData.chunk.terrainData[targetData.localX][voxelCoords.y][targetData.localZ] == VoxelType.BEDROCK)
+    if (targetData.chunk.getVoxel(targetData.localX, voxelCoords.y, targetData.localZ) == VoxelType.BEDROCK)
       return;
     targetData.chunk.updateVoxel(targetData.localX, voxelCoords.y, targetData.localZ, VoxelType.AIR);
   }
@@ -72,7 +72,7 @@ export class InputManager {
     if (!targetData) return;
 
     if (event.button === 0) { // Botón izquierdo: eliminar voxel
-      if (targetData.chunk.terrainData[targetData.localX][voxelCoords.y][targetData.localZ] == VoxelType.BEDROCK)
+      if (targetData.chunk.getVoxel(targetData.localX, voxelCoords.y, targetData.localZ) == VoxelType.BEDROCK)
         return;
       targetData.chunk.updateVoxel(targetData.localX, voxelCoords.y, targetData.localZ, VoxelType.AIR);
     } else if (event.button === 2) { // Botón derecho: agregar voxel
@@ -82,7 +82,7 @@ export class InputManager {
       if (this.checkPlayerPosition(addCoords.x, addCoords.y, addCoords.z)) return;
       const addData = this.getChunkAndLocalCoords(addCoords.x, addCoords.y, addCoords.z);
       if (!addData) return;
-      if (addData.chunk.terrainData[addData.localX][addCoords.y][addData.localZ] !== VoxelType.AIR)
+      if (addData.chunk.getVoxel(addData.localX, addCoords.y, addData.localZ) !== VoxelType.AIR)
         return;
       addData.chunk.updateVoxel(addData.localX, addCoords.y, addData.localZ, VoxelType.TRUNK);
     }

--- a/src/world/ChunkManager.ts
+++ b/src/world/ChunkManager.ts
@@ -218,8 +218,8 @@ export class ChunkManager {
     const localX = globalX - chunk.x * this.chunkSize;
     const localZ = globalZ - chunk.z * this.chunkSize;
     if (localX < 0 || localX >= chunk.size || localZ < 0 || localZ >= chunk.size) return false;
-    if (globalY < 0 || globalY >= chunk.terrainData[localX].length) return false;
-    return chunk.terrainData[localX][globalY][localZ] === voxelType;
+    if (globalY < 0 || globalY >= chunk.maxHeight) return false;
+    return chunk.getVoxel(localX, globalY, localZ) === voxelType;
   }
 
   public getVoxelType(globalX: number, globalY: number, globalZ: number): VoxelType | null {
@@ -230,7 +230,7 @@ export class ChunkManager {
     const localX = globalX - chunk.x * this.chunkSize;
     const localZ = globalZ - chunk.z * this.chunkSize;
     if (localX < 0 || localX >= chunk.size || localZ < 0 || localZ >= chunk.size) return null;
-    if (globalY < 0 || globalY >= chunk.terrainData[localX].length) return null;
-    return chunk.terrainData[localX][globalY][localZ];
+    if (globalY < 0 || globalY >= chunk.maxHeight) return null;
+    return chunk.getVoxel(localX, globalY, localZ);
   }
 }


### PR DESCRIPTION
## Summary
- refactor `TerrainGenerator` to allocate voxel data in a `Uint8Array`
- update mesh and voxel access in `Chunk`
- adapt input and chunk management to new storage layout

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e716e9284832b84c0b8a08759d63a