### PR TITLE
Introduce NPC pathfinding manager

### DIFF
--- a/src/npc/MobManager.ts
+++ b/src/npc/MobManager.ts
@@ -3,20 +3,23 @@ import { Zombie } from './Zombie';
 import { World } from '../world/World';
 import { ChunkManager } from '../world/ChunkManager';
 import { VoxelType } from '../world/TerrainGenerator';
+import { PathfindingManager } from './PathfindingManager';
 
 export class MobManager {
   private mobs: Zombie[] = [];
   private world: World;
   private chunkManager: ChunkManager;
+  private pathManager: PathfindingManager;
   private spawned: boolean = false;
 
   constructor(world: World, chunkManager: ChunkManager) {
     this.world = world;
     this.chunkManager = chunkManager;
+    this.pathManager = new PathfindingManager(chunkManager);
   }
 
   public spawnZombie(position: THREE.Vector3) {
-    const zombie = new Zombie(position, this.chunkManager);
+    const zombie = new Zombie(position, this.chunkManager, this.pathManager);
     this.mobs.push(zombie);
     this.world.scene.add(zombie.mesh);
   }
@@ -59,6 +62,7 @@ export class MobManager {
   }
 
   public update(delta: number, playerPosition: THREE.Vector3) {
+    this.pathManager.update();
     const isNight = this.world.isNight();
     if (isNight) {
       if (!this.spawned) {

--- a/src/npc/PathfindingManager.ts
+++ b/src/npc/PathfindingManager.ts
@@ -1,0 +1,45 @@
+import * as THREE from 'three';
+import { Pathfinder } from './Pathfinder';
+import { ChunkManager } from '../world/ChunkManager';
+
+interface PathRequest {
+  start: THREE.Vector3;
+  goal: THREE.Vector3;
+  resolve: (path: THREE.Vector3[]) => void;
+  reject: (err?: any) => void;
+}
+
+export class PathfindingManager {
+  private queue: PathRequest[] = [];
+  private processing: boolean = false;
+  private pathfinder: Pathfinder;
+
+  constructor(chunkManager: ChunkManager) {
+    this.pathfinder = new Pathfinder(chunkManager);
+  }
+
+  public isWalkable(x: number, y: number, z: number): boolean {
+    return this.pathfinder.isWalkable(x, y, z);
+  }
+
+  public requestPath(start: THREE.Vector3, goal: THREE.Vector3): Promise<THREE.Vector3[]> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ start: start.clone(), goal: goal.clone(), resolve, reject });
+    });
+  }
+
+  public update(): void {
+    if (this.processing || this.queue.length === 0) return;
+
+    const { start, goal, resolve, reject } = this.queue.shift()!;
+    this.processing = true;
+    try {
+      const path = this.pathfinder.findPath(start, goal);
+      resolve(path);
+    } catch (err) {
+      reject(err);
+    } finally {
+      this.processing = false;
+    }
+  }
+}

--- a/src/npc/Zombie.ts
+++ b/src/npc/Zombie.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { Mob } from './Mob';
 import { ChunkManager } from '../world/ChunkManager';
+import { PathfindingManager } from './PathfindingManager';
 
 export class Zombie extends Mob {
   private state: 'wandering' | 'chasing' = 'wandering';
@@ -9,8 +10,8 @@ export class Zombie extends Mob {
   private readonly detectRange = 10;
   private readonly wanderRadius = 5;
 
-  constructor(position: THREE.Vector3, chunkManager: ChunkManager) {
-    super(position, chunkManager);
+  constructor(position: THREE.Vector3, chunkManager: ChunkManager, pathManager: PathfindingManager) {
+    super(position, chunkManager, pathManager);
     this.spawnPoint = position.clone();
   }
 


### PR DESCRIPTION
## Summary
- add `PathfindingManager` to centralize A* path requests
- change `Mob` to use the manager asynchronously
- update mob manager and zombie classes for the new pathfinding flow

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e7c33deac832b81472489d04f9c8e