### PR TITLE
Improve pathfinder with configurable step height

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # Voxel Engine
+
+A simple browser-based voxel engine built with Three.js and TypeScript.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) (version 18 or higher recommended)
+- npm (comes with Node.js)
+
+## Installation
+
+Install the project dependencies:
+
+```bash
+npm install
+```
+
+## Running the project
+
+Start the development server with:
+
+```bash
+npm run dev
+```
+
+To create a production build use:
+
+```bash
+npm run build
+```
+
+The engine renders a voxel world and includes basic NPC pathfinding.
+

--- a/src/npc/Mob.ts
+++ b/src/npc/Mob.ts
@@ -18,6 +18,7 @@ export abstract class Mob {
   protected chunkManager: ChunkManager;
   protected timeSinceLastPath: number = 0;
   protected recomputeInterval: number = 0.5;
+  protected maxStepHeight: number;
 
   // Basic physics parameters
   protected readonly gravity: number = 25;
@@ -27,10 +28,16 @@ export abstract class Mob {
   protected readonly epsilon: number = 0.001;
   protected tempVec: THREE.Vector3 = new THREE.Vector3();
 
-  constructor(position: THREE.Vector3, chunkManager: ChunkManager, pathManager: PathfindingManager) {
+  constructor(
+    position: THREE.Vector3,
+    chunkManager: ChunkManager,
+    pathManager: PathfindingManager,
+    maxStepHeight: number = 1
+  ) {
     this.position = position.clone();
     this.chunkManager = chunkManager;
     this.pathManager = pathManager;
+    this.maxStepHeight = maxStepHeight;
     this.mesh = this.createMesh();
     this.mesh.position.copy(this.position);
   }
@@ -47,7 +54,7 @@ export abstract class Mob {
       !this.pendingPath
     ) {
       this.pendingPath = this.pathManager
-        .requestPath(this.position, target)
+        .requestPath(this.position, target, this.maxStepHeight)
         .then(path => {
           this.path = path;
           this.pathIndex = 0;

--- a/src/npc/Pathfinder.ts
+++ b/src/npc/Pathfinder.ts
@@ -51,7 +51,12 @@ export class Pathfinder {
     return head === VoxelType.AIR && above === VoxelType.AIR;
   }
 
-  public findPath(start: THREE.Vector3, goal: THREE.Vector3, maxSteps = 2048): THREE.Vector3[] {
+  public findPath(
+    start: THREE.Vector3,
+    goal: THREE.Vector3,
+    maxSteps = 2048,
+    stepHeight = 1
+  ): THREE.Vector3[] {
     const sx = Math.floor(start.x);
     const sy = Math.floor(start.y);
     const sz = Math.floor(start.z);
@@ -99,11 +104,11 @@ export class Pathfinder {
       }
 
       for (const d of dirs) {
-        for (let dy = -1; dy <= 1; dy++) {
+        for (let dy = -stepHeight; dy <= stepHeight; dy++) {
           const nx = current.pos.x + d.x;
           const ny = current.pos.y + dy;
           const nz = current.pos.z + d.z;
-          if (Math.abs(ny - current.pos.y) > 1) continue;
+          if (Math.abs(ny - current.pos.y) > stepHeight) continue;
           if (!this.isWalkable(nx, ny, nz, true)) continue;
 
           const k = this.key(nx, ny, nz);

--- a/src/npc/PathfindingManager.ts
+++ b/src/npc/PathfindingManager.ts
@@ -5,6 +5,7 @@ import { ChunkManager } from '../world/ChunkManager';
 interface PathRequest {
   start: THREE.Vector3;
   goal: THREE.Vector3;
+  stepHeight: number;
   resolve: (path: THREE.Vector3[]) => void;
   reject: (err?: any) => void;
 }
@@ -22,19 +23,29 @@ export class PathfindingManager {
     return this.pathfinder.isWalkable(x, y, z);
   }
 
-  public requestPath(start: THREE.Vector3, goal: THREE.Vector3): Promise<THREE.Vector3[]> {
+  public requestPath(
+    start: THREE.Vector3,
+    goal: THREE.Vector3,
+    stepHeight: number = 1
+  ): Promise<THREE.Vector3[]> {
     return new Promise((resolve, reject) => {
-      this.queue.push({ start: start.clone(), goal: goal.clone(), resolve, reject });
+      this.queue.push({
+        start: start.clone(),
+        goal: goal.clone(),
+        stepHeight,
+        resolve,
+        reject
+      });
     });
   }
 
   public update(): void {
     if (this.processing || this.queue.length === 0) return;
 
-    const { start, goal, resolve, reject } = this.queue.shift()!;
+    const { start, goal, stepHeight, resolve, reject } = this.queue.shift()!;
     this.processing = true;
     try {
-      const path = this.pathfinder.findPath(start, goal);
+      const path = this.pathfinder.findPath(start, goal, 2048, stepHeight);
       resolve(path);
     } catch (err) {
       reject(err);


### PR DESCRIPTION
## Summary
- allow PathfindingManager to accept a step height
- expose `maxStepHeight` in `Mob` and use it when requesting a path
- update Pathfinder to use `stepHeight` when exploring neighbours
- document setup and running instructions

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685339e16920832b93039cecb3e2084c